### PR TITLE
Expand the Ribbon Menu on the application window.

### DIFF
--- a/builder/src/main/java/builder/views/Ribbon.java
+++ b/builder/src/main/java/builder/views/Ribbon.java
@@ -106,9 +106,9 @@ public class Ribbon extends JPanel {
     
     toolBox.setSelected(true);
 
-    ribbonBar.setPreferredSize(new Dimension(1045,135));
-
-    add(ribbonBar, BorderLayout.CENTER);
+   // ribbonBar.setPreferredSize(new Dimension(1045,135));
+    setLayout(new BorderLayout());
+    add(ribbonBar, BorderLayout.NORTH);
     
   }
   


### PR DESCRIPTION
Currently, increasing the size of the app keeps the menu in the middle. I think it would be better if the menu scaled with it.
I would like to suggest this small change.

Krisz--